### PR TITLE
fix(): upgrade Apache Tomcat to 10.1.41

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
     </spring.cloud.starter.aws.secrets.manager.config.version>
     <aws-java-sdk.version>1.12.579</aws-java-sdk.version>
     <aws-xray-recorder-sdk.version>2.14.0</aws-xray-recorder-sdk.version>
-    <tomcat-embed.version>10.1.15</tomcat-embed.version>
+    <tomcat-embed.version>10.1.41</tomcat-embed.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- Bumps Apache Tomcat from 10.1.15 → 10.1.41.
  - Resolves CVE-2025-24813
  - Resolves CVE-2025-31650
  - Resolves CVE-2024-56337
  - Resolves CVE-2024-50379
  - Resolves CVE-2024-34750
  - Resolves CVE-2024-24549
  - Resolves CVE-2025-31651
- Adds `.vscode` nullable annotation.